### PR TITLE
Implement Default Insert IM option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The options are similar in different platform.
 | Option              | Defination                                                                                                   |
 | ------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `Default IM`        | specify the input method used in normal mode                                                                 |
+| `Default Insert IM` | specify the input method used in insert mode                                                     |
+| `Default Visual IM` | specify the input method used in visual mode                                                 |
+| `Default Replace IM` | specify the input method used in replace mode                                                |
 | `Obtaining Command` | Command to obtain current input method (must be excutable)                                                   |
 | `Switching Command` | Command to switch current input method (must be excutable, use `{im}` as placeholder of target input method) |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -26,6 +26,9 @@
 | 选项                | 定义                                                                 |
 | ------------------- | -------------------------------------------------------------------- |
 | `Default IM`        | 指定normal模式下使用的输入法                                         |
+| `Default Insert IM`        | 指定insert模式下使用的输入法 |
+| `Default Visual IM`        | 指定visual模式下使用的输入法 |
+| `Default Replace IM`        | 指定replace模式下使用的输入法 |
 | `Obtaining Command` | 获得当前输入法的命令（必须是可执行的）                               |
 | `Switching Command` | 切换当前输入法的命令（必须是可执行的，使用`{im}`来代表输入法的位置） |
 


### PR DESCRIPTION
## Summary
- add `defaultInsertIM` settings for general and Windows
- initialize `currentInsertIM` from the new setting when available
- switch IM in insert/normal mode using `defaultInsertIM`
- document the new configuration option in English and Chinese READMEs

## Testing
- `npm run build` *(fails: Cannot find package 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6863d150a2688321bfd50fbc46c47b44