### PR TITLE
Add vim keypress support and vault chdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The options are similar in different platform.
 | `Default IM`        | specify the input method used in normal mode                                                                 |
 | `Default Insert IM` | specify the input method used in insert mode                                                     |
 | `Default Visual IM` | specify the input method used in visual mode                                                 |
-| `Default Replace IM` | specify the input method used in replace mode                                                |
+| `Default Replace IM` | specify the input method used in replace mode, include continuous replace mode (R) and single-character replace mode (r).                                                |
 | `Obtaining Command` | Command to obtain current input method (must be excutable)                                                   |
 | `Switching Command` | Command to switch current input method (must be excutable, use `{im}` as placeholder of target input method) |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -28,7 +28,7 @@
 | `Default IM`        | 指定normal模式下使用的输入法                                         |
 | `Default Insert IM`        | 指定insert模式下使用的输入法 |
 | `Default Visual IM`        | 指定visual模式下使用的输入法 |
-| `Default Replace IM`        | 指定replace模式下使用的输入法 |
+| `Default Replace IM`        | 指定replace模式下使用的输入法，包括连续替换模式（R）以及单字符替换模式（r） |
 | `Obtaining Command` | 获得当前输入法的命令（必须是可执行的）                               |
 | `Switching Command` | 切换当前输入法的命令（必须是可执行的，使用`{im}`来代表输入法的位置） |
 

--- a/main.ts
+++ b/main.ts
@@ -65,9 +65,23 @@ export default class VimImPlugin extends Plugin {
         private currentReplaceIM = '';
         private previousMode = '';
         private isWinPlatform = false;
+        private onVimKeypress = async (key: string) => {
+                if (key === "<Esc>") {
+                        console.info("press esc");
+                        this.switchToNormal();
+                        return;
+                }
+                if (key === "r") {
+                        console.info("press r");
+                        this.switchToInsert();
+                        return;
+                }
+        };
 
-	async onload() {
-		await this.loadSettings();
+        async onload() {
+                await this.loadSettings();
+                const vaultDir = this.app.vault.adapter.getBasePath();
+                process.chdir(vaultDir);
 
 		// when open a file, to initialize current
 		// editor type CodeMirror5 or CodeMirror6
@@ -75,10 +89,12 @@ export default class VimImPlugin extends Plugin {
 			const view = this.getActiveView();
 			if (view) {
 				const editor = this.getCodeMirror(view);
-				if (editor) {
-					editor.off('vim-mode-change', this.onVimModeChanged);
-					editor.on('vim-mode-change', this.onVimModeChanged);
-				}
+                                if (editor) {
+                                        editor.off('vim-mode-change', this.onVimModeChanged);
+                                        editor.on('vim-mode-change', this.onVimModeChanged);
+                                        editor.off('vim-keypress', this.onVimModeChanged);
+                                        editor.on('vim-keypress', this.onVimKeypress);
+                                }
 			}
 		});
 
@@ -233,19 +249,24 @@ export default class VimImPlugin extends Plugin {
 
         onVimModeChanged = async (modeObj: any) => {
                 if (isEmpty(modeObj)) {
+                        console.info("empty");
                         return;
                 }
                 switch (modeObj.mode) {
                         case "insert":
                                 this.switchToInsert();
+                                console.info("insert");
                                 break;
                         case "visual":
                                 this.switchToVisual();
+                                console.info("visual");
                                 break;
                         case "replace":
                                 this.switchToReplace();
+                                console.info("replace");
                                 break;
                         default:
+                                console.info("normal");
                                 if (this.previousMode === "normal") {
                                         break;
                                 }


### PR DESCRIPTION
## Summary
- hook up `vim-keypress` events in editors
- log Vim mode changes and respond to `<Esc>` and `r` keypresses
- change working directory to the active vault on load

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864bd56b53c83219ca2a6749e21e2c8